### PR TITLE
Add `name` to list of ignored function attributes to fix MSEdge

### DIFF
--- a/src/pacomo.js
+++ b/src/pacomo.js
@@ -14,7 +14,7 @@ export function prefixedClassNames(prefix, ...args) {
 
 
 const ignoredFunctionStatics =
-  Object.getOwnPropertyNames(function(){}).concat(['displayName', 'propTypes'])
+  Object.getOwnPropertyNames(function(){}).concat(['displayName', 'propTypes', 'name'])
 
 
 function hoistFunctionStatics(source, target) {


### PR DESCRIPTION
Pacomo transformer fails on Microsoft Edge because it tries to copy the `name` property of the function being wrapped. This is because `Object.getOwnPropertyNames` includes `name` on the named function but not on `function () {}`, so `name` is not in the banned list `ignoredFunctionStatics`.

Chrome works because `function () {}` has a `name` property, IE11 works for the opposite reason─the source function lacks a `name` property!

Suggested fix is to add `name` to the additional hard-coded banned list.
