### PR TITLE
Support for packageName as optional

### DIFF
--- a/src/pacomo.js
+++ b/src/pacomo.js
@@ -114,7 +114,7 @@ export function withPackageName(packageName) {
     // Transform a stateless function component
     transformer(componentFunction) {
       const componentName = componentFunction.displayName || componentFunction.name
-      const prefix = `${packageName}-${componentName}`
+      const prefix = packageName ? `${packageName}-${componentName}` : componentName;
       const transform = transformWithPrefix(prefix)
 
       const transformedComponent = (props, ...args) =>
@@ -136,7 +136,7 @@ export function withPackageName(packageName) {
     // Transform a React.Component class
     decorator(componentClass) {
       const componentName = componentClass.displayName || componentClass.name
-      const prefix = `${packageName}-${componentName}`
+      const prefix = packageName ? `${packageName}-${componentName}` : componentName;
       const transform = transformWithPrefix(prefix)
 
       const DecoratedComponent = class DecoratedComponent extends componentClass {

--- a/test.js
+++ b/test.js
@@ -211,6 +211,15 @@ describe('#render', () => {
       true
     )
   })
+
+  it("works correctly when packageName is optional", () => {
+    const rendered = shallowRenderComponent(withPackageName().decorator(BareComponent))
+
+    assert.equal(
+      rendered.props.className.trim(),
+      'BareComponent'
+    )
+  })
 })
 
 


### PR DESCRIPTION
I propose to make the package name as optional for small projects or projects that have just one component.

`.datepicker-DatePicker-select`
`.app-DatePicker-select`
`.app-DatePicker-select-option`
...
Depending on the project size, this approach will become costly.

What do you think?
