### PR TITLE
Remove pacomo displayName in component

### DIFF
--- a/src/pacomo.js
+++ b/src/pacomo.js
@@ -124,8 +124,6 @@ export function withPackageName(packageName) {
           props.className
         )
 
-      transformedComponent.displayName = `pacomo(${componentName})`
-
       // Add `className` propType, if none exists
       transformedComponent.propTypes = { className: PropTypes.string, ...componentFunction.propTypes }
 
@@ -148,8 +146,6 @@ export function withPackageName(packageName) {
           return transformed
         }
       }
-
-      DecoratedComponent.displayName = `pacomo(${componentName})`
 
       // Add `className` propType, if none exists
       DecoratedComponent.propTypes = { className: PropTypes.string, ...componentClass.propTypes }


### PR DESCRIPTION
What's the purpose? I think that this can be removed.
See my react-storybook, it's unnecessary and bothers:

![monosnap 2016-05-01 08-31-16](https://cloud.githubusercontent.com/assets/1501013/14941589/2e123c7e-0f77-11e6-835f-2f3c80994846.jpg)
