### PR TITLE
Use the prop-types library instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.1.18",
-    "classnames": "^2.1.3"
+    "classnames": "^2.1.3",
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",

--- a/src/pacomo.js
+++ b/src/pacomo.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
-import { isValidElement, cloneElement, Children, PropTypes } from 'react'
+import PropTypes from 'prop-types'
+import { isValidElement, cloneElement, Children } from 'react'
 
 
 export function prefixedClassNames(prefix, ...args) {
@@ -46,7 +47,7 @@ function transformElementProps(props, fn, childrenOnly) {
       changes.children = transformedChildren
     }
   }
-  
+
   if (!childrenOnly) {
     for (let key of Object.keys(props)) {
       if (key == 'children') continue
@@ -65,7 +66,7 @@ function transformElementProps(props, fn, childrenOnly) {
 
 
 function cloneElementWithSkip(element) {
-  return cloneElement(element, {'data-pacomoSkip': true})
+  return cloneElement(element, {'data-pacomoskip': true})
 }
 
 
@@ -83,7 +84,7 @@ export function transformWithPrefix(prefix) {
   //
   // Optionally prefix with a `rootClass` and postfix with `suffixClass`.
   function transform(element, rootClass, suffixClasses='') {
-    if (typeof element !== 'object' || element.props['data-pacomoSkip']) return element
+    if (typeof element !== 'object' || element.props['data-pacomoskip']) return element
 
     const changes = transformElementProps(
       element.props,
@@ -150,7 +151,7 @@ export function withPackageName(packageName) {
       // Add `className` propType, if none exists
       DecoratedComponent.propTypes = { className: PropTypes.string, ...componentClass.propTypes }
 
-      return DecoratedComponent  
+      return DecoratedComponent
     },
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 import 'babel-polyfill'
 import {prefixedClassNames, withPackageName, transformWithPrefix} from './lib/pacomo'
-import React, {Component, PropTypes} from 'react'
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
 import TestUtils from 'react-addons-test-utils'
 import assert from 'assert'
 
@@ -16,7 +17,7 @@ const { transformer, decorator } = withPackageName('prefix')
 function shallowRenderElement(element) {
  const shallowRenderer = TestUtils.createRenderer()
   shallowRenderer.render(element)
-  return shallowRenderer.getRenderOutput() 
+  return shallowRenderer.getRenderOutput()
 }
 
 function shallowRenderComponent(Component, props) {


### PR DESCRIPTION
To support React 15.5, instead of accessing PropTypes from the main React object,
install the prop-types package and import them from there

See [this discussion topic](https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes)